### PR TITLE
add ipv6 support

### DIFF
--- a/tcpcheck.go
+++ b/tcpcheck.go
@@ -26,7 +26,8 @@ func main() {
 
 	for {
 		start := time.Now()
-		conn, err := net.DialTimeout("tcp", fmt.Sprintf("%s:%d", ip, port), time.Second)
+                addr := fmt.Sprintf("[%s]:%d", ip, port)
+                conn, err := net.DialTimeout("tcp", addr, time.Second)
 		elapsed := time.Since(start)
 		pingMs := elapsed.Seconds() * 1000
 


### PR DESCRIPTION
Now the app can test with IPv4 and IPv6

![Screenshot 2024-01-28 110902](https://github.com/towsifkafi/tcpcheck/assets/80064475/d82d4732-3510-40f7-9939-029264be694a)
